### PR TITLE
Plugin updates for Zeek v4.1.x compatibility

### DIFF
--- a/scripts/S7comm/main.zeek
+++ b/scripts/S7comm/main.zeek
@@ -12,18 +12,18 @@ export {
         LOG_ISO_COTP,
         LOG_S7COMM,
         };
-    
+
     type ISO_COTP: record {
-        ts      : time &optional &log;      ## Time when the command was sent.        
-        uid     : string &optional &log;    ## Unique ID for the connection.        
+        ts      : time &optional &log;      ## Time when the command was sent.
+        uid     : string &optional &log;    ## Unique ID for the connection.
         id      : conn_id &optional &log;   ## The connection's 4-tuple of endpoint addresses/ports.
-    
+
         pdu_type: string &optional &log;    ## COTP message type.
         };
     global log_iso_cotp: event(rec: ISO_COTP);
-    
+
     type S7comm: record {
-        ts          : time &optional &log;          ## Time when the command was sent.    
+        ts          : time &optional &log;          ## Time when the command was sent.
         uid         : string &optional &log;        ## Unique ID for the connection.
         id          : conn_id &optional &log;       ## The connection's 4-tuple of endpoint addresses/ports.
 
@@ -165,11 +165,12 @@ event iso_cotp(c: connection, is_orig: bool,
                 pdu_type: count) &priority=5 {
     if(!c?$iso_cotp) {
         c$iso_cotp = [$ts=network_time(), $uid=c$uid, $id=c$id];
+        add c$service["iso_cotp"];
         }
-        
+
     c$iso_cotp$ts = network_time();
     c$iso_cotp$pdu_type = cotp_types[pdu_type];
-    
+
     Log::write(S7comm::LOG_ISO_COTP, c$iso_cotp);
     }
 
@@ -177,6 +178,7 @@ event s7comm_data(c:connection, is_orig:bool,
                     data:string) {
     if(!c?$s7comm) {
         c$s7comm = [$ts=network_time(), $uid=c$uid, $id=c$id];
+        add c$service["s7comm"];
         }
 
     local data_index: count=0;

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,7 +1,7 @@
 #include "Plugin.h"
-#include "analyzer/Component.h"
+#include "zeek/analyzer/Component.h"
 
-namespace plugin { 
+namespace plugin {
     namespace Zeek_S7comm {
         Plugin plugin;
         }
@@ -9,10 +9,10 @@ namespace plugin {
 
 using namespace plugin::Zeek_S7comm;
 
-plugin::Configuration Plugin::Configure() {
-    AddComponent(new ::analyzer::Component("S7comm", ::analyzer::s7comm::S7comm_Analyzer::Instantiate));
-    
-    plugin::Configuration config;
+zeek::plugin::Configuration Plugin::Configure() {
+    AddComponent(new zeek::analyzer::Component("S7comm", analyzer::s7comm::S7comm_Analyzer::Instantiate));
+
+    zeek::plugin::Configuration config;
     config.name = "Zeek::S7comm";
     config.description = "S7 communnication protocol analyzer";
     return config;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -1,15 +1,15 @@
 #ifndef ZEEK_PLUGIN_ZEEK_S7COMM
 #define ZEEK_PLUGIN_ZEEK_S7COMM
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
 #include "S7comm.h"
 
 namespace plugin {
     namespace Zeek_S7comm {
-        class Plugin : public ::plugin::Plugin {
+        class Plugin : public zeek::plugin::Plugin {
             protected:
                 // Overridden from plugin::Plugin.
-                virtual plugin::Configuration Configure();
+                virtual zeek::plugin::Configuration Configure();
             };
 
         extern Plugin plugin;

--- a/src/S7comm.cc
+++ b/src/S7comm.cc
@@ -1,11 +1,11 @@
 #include "S7comm.h"
-#include "analyzer/protocol/tcp/TCP_Reassembler.h"
-#include "Reporter.h"
+#include <zeek/analyzer/protocol/tcp/TCP_Reassembler.h>
+#include <zeek/Reporter.h>
 #include "events.bif.h"
 
 using namespace analyzer::s7comm;
 
-S7comm_Analyzer::S7comm_Analyzer(Connection* c): tcp::TCP_ApplicationAnalyzer("S7comm", c) {
+S7comm_Analyzer::S7comm_Analyzer(zeek::Connection* c): zeek::analyzer::tcp::TCP_ApplicationAnalyzer("S7comm", c) {
     interp = new binpac::S7comm::S7comm_Conn(this);
     had_gap = false;
     }
@@ -15,18 +15,18 @@ S7comm_Analyzer::~S7comm_Analyzer() {
     }
 
 void S7comm_Analyzer::Done() {
-    tcp::TCP_ApplicationAnalyzer::Done();
+    zeek::analyzer::tcp::TCP_ApplicationAnalyzer::Done();
     interp->FlowEOF(true);
     interp->FlowEOF(false);
     }
 
 void S7comm_Analyzer::EndpointEOF(bool is_orig) {
-    tcp::TCP_ApplicationAnalyzer::EndpointEOF(is_orig);
+    zeek::analyzer::tcp::TCP_ApplicationAnalyzer::EndpointEOF(is_orig);
     interp->FlowEOF(is_orig);
     }
 
 void S7comm_Analyzer::DeliverStream(int len, const u_char* data, bool orig) {
-    tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
+    zeek::analyzer::tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
     assert(TCP());
     //if(TCP()->IsPartial())
     //    return;
@@ -39,12 +39,12 @@ void S7comm_Analyzer::DeliverStream(int len, const u_char* data, bool orig) {
         interp->NewData(orig, data, data + len);
         }
     catch(const binpac::Exception& e) {
-        ProtocolViolation(fmt("Binpac exception: %s", e.c_msg()));
+        ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
         }
     }
 
 void S7comm_Analyzer::Undelivered(uint64_t seq, int len, bool orig) {
-    tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
+    zeek::analyzer::tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
     had_gap = true;
     interp->NewGap(orig, len);
     }

--- a/src/S7comm.h
+++ b/src/S7comm.h
@@ -1,14 +1,14 @@
 #ifndef ANALYZER_PROTOCOL_S7COMM_H
 #define ANALYZER_PROTOCOL_S7COMM_H
 
-#include "analyzer/protocol/tcp/TCP.h"
+#include <zeek/analyzer/protocol/tcp/TCP.h>
 #include "s7comm_pac.h"
 
-namespace analyzer { 
+namespace analyzer {
     namespace s7comm {
-        class S7comm_Analyzer : public tcp::TCP_ApplicationAnalyzer {
+        class S7comm_Analyzer : public zeek::analyzer::tcp::TCP_ApplicationAnalyzer {
             public:
-                S7comm_Analyzer(Connection* conn);
+                S7comm_Analyzer(zeek::Connection* conn);
                 virtual ~S7comm_Analyzer();
 
                 virtual void Done();
@@ -17,7 +17,7 @@ namespace analyzer {
 
                 virtual void EndpointEOF(bool is_orig);
 
-                static analyzer::Analyzer* Instantiate(Connection* conn) { 
+                static zeek::analyzer::Analyzer* Instantiate(zeek::Connection* conn) {
                     return new S7comm_Analyzer(conn);
                     }
 
@@ -25,7 +25,7 @@ namespace analyzer {
                 binpac::S7comm::S7comm_Conn* interp;
                 bool had_gap;
             };
-        } 
+        }
     }
 
 #endif

--- a/src/s7comm.pac
+++ b/src/s7comm.pac
@@ -1,5 +1,5 @@
-%include binpac.pac
-%include bro.pac
+%include zeek/binpac.pac
+%include zeek/zeek.pac
 
 %extern{
     #include "events.bif.h"


### PR DESCRIPTION
- Rename deprecated (now removed) "bro" references to "zeek"
- Fixed various issues in .cc and .pac files for namespaces, renamed
  types, include file locations, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
